### PR TITLE
Fix thread safety issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
     "sass-loader": "^11.0.1",
     "unomi-analytics": "^1.0.10"
   },
+"resolutions": {
+    "@apollo/client": "3.5.10"
+  },
   "devDependencies": {
     "@babel/compat-data": "^7.9.0",
     "@babel/core": "^7.9.0",

--- a/src/main/java/org/jahia/se/modules/consentManager/ConsentManager.java
+++ b/src/main/java/org/jahia/se/modules/consentManager/ConsentManager.java
@@ -18,84 +18,13 @@ import java.util.List;
 @Component(service = RenderFilter.class)
 public class ConsentManager extends AbstractFilter {
     private static Logger logger = LoggerFactory.getLogger(ConsentManager.class);
-//    private String gtHeadScript;
-//    private String gtBodyScript;
-    private String headScript;
-    private String bodyHtmlHook;
-    private String bodyScript;
     private final static String CONSENT_MANAGER_MIX="jmix:consentManager";
-
+    
     @Activate
     public void activate() {
-//        setApplyOnModules("consent-manager");
         setPriority(-1);
-//        setApplyOnEditMode(true);
         setApplyOnModes("live,preview");
-//        setSkipOnAjaxRequest(true);
         setApplyOnConfigurations("page");
-//        setApplyOnTemplateTypes("html,html-*");
-    }
-
-    @Override
-    public String prepare(RenderContext renderContext, Resource resource, RenderChain chain) throws Exception {
-        JCRSiteNode site = renderContext.getSite();
-        String siteUUID = site.getIdentifier();
-        String jsid = siteUUID.replace('-','_');
-        String hookId = "consent_manager_"+jsid;
-        String contextId = "consent_manager_ctx_"+jsid;
-
-//TEMP Google tag Manager Event triggered Test
-//        StringBuilder headGoogleTagManagerScriptBuilder = new StringBuilder("<!-- Google Tag Manager -->");
-//        headGoogleTagManagerScriptBuilder.append("<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':");
-//        headGoogleTagManagerScriptBuilder.append("new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],");
-//        headGoogleTagManagerScriptBuilder.append("j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=");
-//        headGoogleTagManagerScriptBuilder.append("'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);");
-//        headGoogleTagManagerScriptBuilder.append("})(window,document,'script','dataLayer','GTM-TQC2CZH');</script>");
-//        headGoogleTagManagerScriptBuilder.append("<!-- End Google Tag Manager -->");
-//        gtHeadScript = headGoogleTagManagerScriptBuilder.toString();
-//
-//        StringBuilder bodyGoogleTagManagerScriptBuilder = new StringBuilder("<!-- Google Tag Manager (noscript) -->");
-//        bodyGoogleTagManagerScriptBuilder.append("<noscript><iframe src=\"https://www.googletagmanager.com/ns.html?id=GTM-TQC2CZH\"");
-//        bodyGoogleTagManagerScriptBuilder.append("height=\"0\" width=\"0\" style=\"display:none;visibility:hidden\"></iframe></noscript>");
-//        bodyGoogleTagManagerScriptBuilder.append("<!-- End Google Tag Manager (noscript) -->");
-//        gtBodyScript = bodyGoogleTagManagerScriptBuilder.toString();
-//\TEMP Google tag Manager Event triggered Test
-
-
-        StringBuilder headScriptBuilder =
-            new StringBuilder( "\n<link href=\"https://fonts.googleapis.com/css?family=Lato:300,400,700,900\" rel=\"stylesheet\">" );
-        headScriptBuilder.append( "\n<script type=\"text/javascript\" src=\"/modules/consent-manager/javascript/webapp/consentManager-vendors.js\"></script>" );
-        headScriptBuilder.append( "\n<script type=\"text/javascript\" src=\"/modules/consent-manager/javascript/webapp/consentManager.js\"></script>\n<");
-        headScript = headScriptBuilder.toString();
-
-
-        StringBuilder bodyScriptBuilder = new StringBuilder( "\n<script type=\"text/javascript\">" );
-        bodyScriptBuilder.append("\n(function () {");
-        bodyScriptBuilder.append("\n  const "+contextId+" = {");
-//        bodyScriptBuilder.append("    ctx: \""+${url.context}+"\",");
-        bodyScriptBuilder.append("\n    language: \""+resource.getLocale()+"\",");
-//        bodyScriptBuilder.append("\n    uiLanguage: \""+renderContext.getUILocale().getLanguage()+"\",");
-        bodyScriptBuilder.append("\n    siteUUID: \""+siteUUID+"\",");
-        bodyScriptBuilder.append("\n    siteName: \""+site.getName()+"\",");
-        bodyScriptBuilder.append("\n    siteKey: \""+site.getSiteKey()+"\",");
-        bodyScriptBuilder.append("\n    workspace: \""+renderContext.getWorkspace()+"\",");
-        bodyScriptBuilder.append("\n    baseURL: window.location.protocol + '//' + window.location.host,");
-        bodyScriptBuilder.append("\n    cdpEndPoint:window.digitalData?window.digitalData.contextServerPublicUrl:undefined,");//digitalData is set in live mode only
-//        bodyScriptBuilder.append("\n    gql_endpoint: window.location.protocol + '//' + window.location.host + '/modules/graphql',");
-        bodyScriptBuilder.append("\n    gqlAuthorization:\"Basic cm9vdDpyb290\",");
-//        bodyScriptBuilder.append("\n    gql_variables:{");
-//        bodyScriptBuilder.append("\n      id:\""+siteUUID+"\",");
-//        bodyScriptBuilder.append("\n      language: \""+resource.getLocale()+"\",");
-//        bodyScriptBuilder.append("\n      workspace: \"EDIT\",");
-//        bodyScriptBuilder.append("\n    },");
-        bodyScriptBuilder.append("\n  };");
-        bodyScriptBuilder.append("\n  window.jahiaConsentManager(\""+hookId+"\", "+contextId+");");
-        bodyScriptBuilder.append("\n})();");
-        bodyScriptBuilder.append("\n</script>\n<");
-        bodyScript = bodyScriptBuilder.toString();
-        bodyHtmlHook = "\n<div id=\""+hookId+"\">Loading...</div>";
-
-        return super.prepare(renderContext, resource, chain);
     }
 
     @Override
@@ -107,7 +36,7 @@ public class ConsentManager extends AbstractFilter {
         boolean isCEPreview = renderContext.getRequest().getAttribute("ce_preview") != null;
 
         if(hasConsentManagerEnabled && !isCEPreview)
-            output = enhanceOutput(output);
+            output = enhanceOutput(output, renderContext);
 
         return output;
     }
@@ -119,11 +48,20 @@ public class ConsentManager extends AbstractFilter {
      * @return          Modified output
      */
     @NotNull
-    private String enhanceOutput(String output) {
+    private String enhanceOutput(String output, RenderContext renderContext) throws Exception{
 
         Source source = new Source(output);
         OutputDocument outputDocument = new OutputDocument(source);
 
+        JCRSiteNode site = renderContext.getSite();
+        String siteUUID = site.getIdentifier();
+        String jsid = siteUUID.replace('-','_');
+        
+        String hookId = "consent_manager_"+jsid;
+       
+        String contextId = "consent_manager_ctx_"+jsid;
+        String bodyScript = this.getBodyScript(hookId, siteUUID, site.getName(), site.getSiteKey(), 
+            contextId, renderContext.getMainResourceLocale().toString(), renderContext.getWorkspace());
         //Add webapp script to the HEAD tag
         List<Element> elementList = source.getAllElements(HTMLElementName.HEAD);
         if (elementList != null && !elementList.isEmpty()) {
@@ -131,7 +69,7 @@ public class ConsentManager extends AbstractFilter {
 //            outputDocument.replace(headStartTag.getEnd(), headStartTag.getEnd() + 1, gtHeadScript);
 
             final EndTag headEndTag = elementList.get(0).getEndTag();
-            outputDocument.replace(headEndTag.getBegin(), headEndTag.getBegin() + 1, headScript);
+            outputDocument.replace(headEndTag.getBegin(), headEndTag.getBegin() + 1, getHeadScript());
         }
 
         //Add context script and html hook to the BODY tag
@@ -141,10 +79,48 @@ public class ConsentManager extends AbstractFilter {
 //            outputDocument.replace(bodyStartTag.getEnd(), bodyStartTag.getEnd() + 1, gtBodyScript);
 
             final EndTag bodyEndTag = elementList.get(0).getEndTag();
-            outputDocument.replace(bodyEndTag.getBegin(), bodyEndTag.getBegin() + 1, bodyHtmlHook+bodyScript);
+            outputDocument.replace(bodyEndTag.getBegin(), bodyEndTag.getBegin() + 1, getBodyHtmlHook(hookId)+bodyScript);
         }
 
         output = outputDocument.toString().trim();
         return output;
     }
+
+    private String getBodyHtmlHook(String hookId){
+        return "\n<div id=\""+hookId+"\">Loading...</div>";
+    }
+
+    private String getHeadScript(){
+        StringBuilder headScriptBuilder =
+            new StringBuilder( "\n<link href=\"https://fonts.googleapis.com/css?family=Lato:300,400,700,900\" rel=\"stylesheet\">" );
+        headScriptBuilder.append( "\n<script type=\"text/javascript\" src=\"/modules/consent-manager/javascript/webapp/consentManager-vendors.js\"></script>" );
+        headScriptBuilder.append( "\n<script type=\"text/javascript\" src=\"/modules/consent-manager/javascript/webapp/consentManager.js\"></script>\n<");
+        return headScriptBuilder.toString();
+    }
+
+    private String getBodyScript(String hookId, String siteUUID, String siteName, 
+        String siteKey, String contextId, String locale, String workspace){
+        
+        StringBuilder bodyScriptBuilder = new StringBuilder( "\n<script type=\"text/javascript\">" );
+        bodyScriptBuilder.append("\n//consentManager 1.0.3.1");
+        bodyScriptBuilder.append("\n(function () {");
+        bodyScriptBuilder.append("\n  const "+contextId+" = {");
+        bodyScriptBuilder.append("\n    language: \""+locale+"\",");
+        bodyScriptBuilder.append("\n    siteUUID: \""+siteUUID+"\",");
+        bodyScriptBuilder.append("\n    siteName: \""+siteName+"\",");
+        bodyScriptBuilder.append("\n    siteKey: \""+siteKey+"\",");
+        bodyScriptBuilder.append("\n    workspace: \"" + workspace+ "\",");
+        bodyScriptBuilder.append("\n    baseURL: window.location.protocol + '//' + window.location.host,");
+        bodyScriptBuilder.append("\n    cdpEndPoint:window.digitalData?window.digitalData.contextServerPublicUrl:undefined,");//digitalData is set in live mode only
+        bodyScriptBuilder.append("\n    gqlAuthorization:\"Basic cm9vdDpyb290\",");
+
+        bodyScriptBuilder.append("\n  };");
+        bodyScriptBuilder.append("\n  window.jahiaConsentManager(\""+hookId+"\", "+contextId+");");
+        bodyScriptBuilder.append("\n})();");
+        bodyScriptBuilder.append("\n</script>\n<");
+        return bodyScriptBuilder.toString();
+    }
 }
+
+
+


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->


## Description

Changed the ConsentManager render filter to not use class variables for the head script and body script because they aren't thread safe.

Also added a specific version of apollo client to the package.json.  The latest version of `@apollo/client` as required by `@apollo/react-hooks` doesn't run with the current code so it's being forced to `3.5.10`.

Also noticed that the yarn.lock file wasn't committed to the repo.  Without that, we had to figure out the dependencies for the apollo client on our own and then add the `resolutions` section to force the version.  Without the yarn.lock file other package updates could result in breaking the React app like happened with the Apollo client.









